### PR TITLE
proto: Update protobufs to match latest release.

### DIFF
--- a/proto/eopa/data/v1/data.proto
+++ b/proto/eopa/data/v1/data.proto
@@ -16,6 +16,7 @@ syntax = "proto3";
 package eopa.data.v1;
 
 import "google/protobuf/struct.proto";
+import "google/protobuf/any.proto";
 
 // DataDocument is a thin wrapper type around a JSON value located at a
 // particular path in the virtual document store.
@@ -95,13 +96,69 @@ message DeleteDataRequest {
 message DeleteDataResponse {
 }
 
+// StreamingDataRequest provides a way to send DataService requests over
+// gRPC streams. Limited batching support is provided via the
+// `writes`/`reads` fields. As in the BulkRW API, if a write operation
+// fails, the entire request will be aborted. Writes are done as a single
+// transaction, reads are done in parallel.
+message StreamingDataRWRequest {
+  // WriteDataRequest provides a union of possible Data request types.
+  // This allows creating arbitrary sequences of data store operations.
+  message WriteRequest {
+    oneof req {
+      CreateDataRequest create = 1;
+      UpdateDataRequest update = 2;
+      DeleteDataRequest delete = 3;
+    }
+  }
+  // ReadRequest is currently a simple wrapper over the GetData
+  // request type.
+  message ReadRequest {
+    GetDataRequest get = 1;
+  }
+  // writes provides a sequence of WriteData requests.
+  repeated WriteRequest writes = 1;
+  // reads provides a sequence of ReadData requests.
+  repeated ReadRequest reads = 2;
+}
+
+// StreamingDataRWResponse contains lists of the appropriate response types
+// for each operation in the StreamingDataRWRequest.
+message StreamingDataRWResponse {
+  // WriteResponse provides a union of possible Data request types.
+  // This allows creating arbitrary sequences of data store operations.
+  message WriteResponse {
+    oneof resp {
+      CreateDataResponse create = 1;
+      UpdateDataResponse update = 2;
+      DeleteDataResponse delete = 3;
+    }
+  }
+  // ReadResponse is currently a simple wrapper over the GetData
+  // request type.
+  message ReadResponse {
+    GetDataResponse get = 1;
+    ErrorList errors = 2;
+  }
+  // writes provides a sequence of WriteData results.
+  repeated WriteResponse writes = 1;
+  // reads provides a sequence of ReadData results or errors.
+  repeated ReadResponse reads = 2;
+}
+
+// Context-dependent error messages.
+message ErrorList {
+  // The errors in the list.
+  repeated google.protobuf.Any errors = 1;
+}
+
 service DataService {
   // CreateData looks up the document by path, and inserts a new JSON value
   // at the end of the path.
   //
   // This is equivalent in functionality to OPA's
   // [Data REST API Create/Overwrite method](https://www.openpolicyagent.org/docs/latest/rest-api/#create-or-overwrite-a-document).
-  rpc GetData(GetDataRequest) returns (GetDataResponse);
+  rpc CreateData(CreateDataRequest) returns (CreateDataResponse);
 
   // GetData looks up the document by path. This can be either a plain JSON
   // value (a "Base" document in OPA parlance), or a rule head (a
@@ -113,7 +170,7 @@ service DataService {
   // Note that the input field should not be wrapped with
   // `{ "input": <value> }`, you can simply put the JSON serialized `<value>`
   // in the input field directly.
-  rpc CreateData(CreateDataRequest) returns (CreateDataResponse);
+  rpc GetData(GetDataRequest) returns (GetDataResponse);
 
   // UpdateData looks up the document by path, and then attempts to perform
   // one of three patching operations at that location: add, remove, or
@@ -129,4 +186,15 @@ service DataService {
   // This is equivalent in functionality to OPA's
   // [Data REST API Delete method](https://www.openpolicyagent.org/docs/latest/rest-api/#delete-a-document).
   rpc DeleteData(DeleteDataRequest) returns (DeleteDataResponse);
+
+  // StreamingDataRW specifies a stream of fixed-structure, batched
+  // read/write operations.
+  //
+  // WriteData operations are executed sequentially, aborting the entire
+  // gRPC call if any operations fail.
+  //
+  // The ReadData operations are then executed in parallel, but will report
+  // errors inline in their responses, instead of aborting the entire gRPC
+  // call.
+  rpc StreamingDataRW(stream StreamingDataRWRequest) returns (stream StreamingDataRWResponse);
 }

--- a/proto/eopa/policy/v1/policy.proto
+++ b/proto/eopa/policy/v1/policy.proto
@@ -15,6 +15,8 @@
 syntax = "proto3";
 package eopa.policy.v1;
 
+import "google/protobuf/any.proto";
+
 // Policy is a thin wrapper type around a Rego policy.
 message Policy {
   string path = 1;
@@ -67,24 +69,73 @@ message DeletePolicyRequest {
 // DeletePolicyResponse is an empty confirmation message type.
 message DeletePolicyResponse {}
 
+// StreamingPolicyRequest provides a way to send PolicyService requests over
+// gRPC streams. Limited batching support is provided via the
+// `writes`/`reads` fields. As in the BulkRW API, if a write operation
+// fails, the entire request will be aborted. Writes are done as a single
+// transaction, reads are done in parallel.
+message StreamingPolicyRWRequest {
+  // WritePolicyRequest provides a union of possible Policy request types.
+  // This allows creating arbitrary sequences of Policy store operations.
+  message WriteRequest {
+    oneof req {
+      CreatePolicyRequest create = 1;
+      UpdatePolicyRequest update = 2;
+      DeletePolicyRequest delete = 3;
+    }
+  }
+  // ReadRequest is currently a simple wrapper over the GetPolicy
+  // request type.
+  message ReadRequest {
+    GetPolicyRequest get = 1;
+  }
+  // writes provides a sequence of WritePolicy requests.
+  repeated WriteRequest writes = 1;
+  // reads provides a sequence of ReadPolicy requests.
+  repeated ReadRequest reads = 2;
+}
+
+// StreamingPolicyRWResponse contains lists of the appropriate response types
+// for each operation in the StreamingPolicyRWRequest.
+message StreamingPolicyRWResponse {
+  // WriteResponse provides a union of possible Policy request types.
+  // This allows creating arbitrary sequences of Policy store operations.
+  message WriteResponse {
+    oneof resp {
+      CreatePolicyResponse create = 1;
+      UpdatePolicyResponse update = 2;
+      DeletePolicyResponse delete = 3;
+    }
+  }
+  // ReadResponse is currently a simple wrapper over the GetPolicy
+  // request type.
+  message ReadResponse {
+    GetPolicyResponse get = 1;
+    ErrorList errors = 2;
+  }
+  // writes provides a sequence of WritePolicy results.
+  repeated WriteResponse writes = 1;
+  // reads provides a sequence of ReadPolicy results or errors.
+  repeated ReadResponse reads = 2;
+}
+
+// Context-dependent error messages.
+message ErrorList {
+  // The errors in the list.
+  repeated google.protobuf.Any errors = 1;
+}
+
+
 service PolicyService {
   // ListPolicies returns the set of stored policies in the policy store.
   //
   // This is equivalent in functionality to OPA's
   // [Policy REST API List method](https://www.openpolicyagent.org/docs/latest/rest-api/#list-policies).
   //
-  // Warning: This request will enumerate *all* policies stored by the Enterprise OPA
-  // instance. This can have substantial overheads if the policies are large
-  // in size.
+  // Warning: This request will enumerate *all* policies stored by the
+  // Enterprise OPA instance. This can have substantial overheads if the
+  // policies are large in size.
   rpc ListPolicies(ListPoliciesRequest) returns (ListPoliciesResponse);
-
-  // GetPolicy fetches a policy module's code from the policy store.
-  //
-  // This is roughly equivalent in functionality to OPA's
-  // [Policy REST API Get method](https://www.openpolicyagent.org/docs/latest/rest-api/#get-a-policy).
-  //
-  // Note: Only the raw policy text is returned in this version of the API.
-  rpc GetPolicy(GetPolicyRequest) returns (GetPolicyResponse);
 
   // CreatePolicy inserts a new policy module into the policy store.
   //
@@ -98,6 +149,14 @@ service PolicyService {
   // number of policies down, or using Bundles are the recommended
   // workarounds for most OPA users.
   rpc CreatePolicy(CreatePolicyRequest) returns (CreatePolicyResponse);
+
+  // GetPolicy fetches a policy module's code from the policy store.
+  //
+  // This is roughly equivalent in functionality to OPA's
+  // [Policy REST API Get method](https://www.openpolicyagent.org/docs/latest/rest-api/#get-a-policy).
+  //
+  // Note: Only the raw policy text is returned in this version of the API.
+  rpc GetPolicy(GetPolicyRequest) returns (GetPolicyResponse);
 
   // UpdatePolicy updates a policy module in the policy store.
   //
@@ -124,4 +183,15 @@ service PolicyService {
   // Keeping the unique number of policies down, or using Bundles are the
   // recommended workarounds for most OPA users.
   rpc DeletePolicy(DeletePolicyRequest) returns (DeletePolicyResponse);
+
+  // StreamingPolicyRW specifies a stream of fixed-structure, batched
+  // read/write operations.
+  //
+  // WritePolicy operations are executed sequentially, aborting the entire
+  // gRPC call if any operations fail.
+  //
+  // The ReadPolicy operations are then executed in parallel, but will report
+  // errors inline in their responses, instead of aborting the entire gRPC
+  // call.
+  rpc StreamingPolicyRW(stream StreamingPolicyRWRequest) returns (stream StreamingPolicyRWResponse);
 }


### PR DESCRIPTION
This commit updates the gRPC definition files to match the `v1.7.0` release's API.