### PR TITLE
kafka-multiple-topics: introduce topic -> kind indirection

### DIFF
--- a/examples/kafka-multiple-topics/transform.rego
+++ b/examples/kafka-multiple-topics/transform.rego
@@ -4,11 +4,18 @@ import rego.v1
 
 _payload(msg) := json.unmarshal(base64.decode(msg.value))
 
-# _id() of a message must be unique across its topic
+# _id() of a message must be unique across its kind
 _id(msg) := json.unmarshal(base64.decode(msg.key))
 
-# _key() of a message with topic T is where we'll store its _values()
-# so on topic "users", message with `_id(msg)` of "ada" and `_values(msg)`
+# _kind() of a message determines where on the resulting data tree its
+# values are to be written. This is useful when you don't want to use the
+# incoming topics as-is.
+_kind(msg) := "groups" if msg.topic == "group-topic"
+
+else := msg.topic
+
+# _key() of a message with kind T is where we'll store its _values()
+# so on kind "users", message with `_id(msg)` of "ada" and `_values(msg)`
 # of {"name": "Ada Lovelace"} will end up as
 #
 # users:
@@ -22,14 +29,14 @@ _values("users", payload) := object.filter(payload, ["name", "roles"]) # for use
 
 _values("groups", payload) := object.remove(payload, ["id", "type"]) # for groups, take everything BUT "type"
 
-_values(topic, payload) := payload if not topic in {"users", "groups"} # for other topics, keep message payload as-is
+_values(kind, payload) := payload if not kind in {"users", "groups"} # for other kinds, keep message payload as-is
 
-# this collects all IDs of the messages in a batch, per topic
-batches[msg.topic][idx] := _key(msg) if some idx, msg in input.incoming
+# this collects all IDs of the messages in a batch, per kind
+batches[_kind(msg)][idx] := _key(msg) if some idx, msg in input.incoming
 
 # incoming messages are parsed and stored under their ID payload field
-transform[topic][_key(msg)] := _values(topic, payload) if {
-	some topic, msgs in incoming_latest
+transform[kind][_key(msg)] := _values(kind, payload) if {
+	some kind, msgs in incoming_latest
 	some _, msg in msgs
 	payload := _payload(msg)
 	not is_delete(payload)
@@ -40,23 +47,23 @@ is_delete(payload) if payload.type == "delete"
 
 # if no new data came in for a certain message, we'll retain the data
 # stored previously
-transform[topic][key] := val if {
-	# we cannot read existing topics from batches, as we'd lose old data
+transform[kind][key] := val if {
+	# we cannot read existing kinds from batches, as we'd lose old data
 	# that has no updates in the incoming batch
-	some topic, existing in input.previous
+	some kind, existing in input.previous
 	some key, val in existing
-	no_news_for_key(topic, key)
+	no_news_for_key(kind, key)
 }
 
-no_news_for_key(topic, _) if not batches[topic]
+no_news_for_key(kind, _) if not batches[kind]
 
-no_news_for_key(topic, key) if not key in object.keys(incoming_latest[topic])
+no_news_for_key(kind, key) if not key in object.keys(incoming_latest[kind])
 
 # input.incoming is an array, iteration order naturally given
-incoming[msg.topic][_key(msg)][batch] := msg if some batch, msg in input.incoming
+incoming[_kind(msg)][_key(msg)][batch] := msg if some batch, msg in input.incoming
 
-incoming_latest[topic][key] := msg if {
-	some topic, xs in incoming
+incoming_latest[kind][key] := msg if {
+	some kind, xs in incoming
 	some key, batch in xs
 
 	# batch is an object! iteration order is unspecified -- but it happens to be sorted

--- a/examples/kafka-multiple-topics/transform_test.rego
+++ b/examples/kafka-multiple-topics/transform_test.rego
@@ -91,3 +91,16 @@ test_unspecific_topic_updates if {
 		with input.incoming as [_kafka_msg("roles", {"id": "admin", "permissions": "all"})]
 	new == {"roles": {"admin": {"id": "admin", "permissions": "all"}}}
 }
+
+test_kind_from_topic_one_message if {
+	new := transform with input.previous as {}
+		with input.incoming as [_kafka_msg("group-topic", {"id": "sci", "name": "scientists"})]
+	new == {"groups": {"sci": {"name": "scientists"}}}
+}
+
+test_kind_from_topic_with_updates if {
+	# alice gets an update, ruth's record must be kept, maga is deleted
+	new := transform with input.previous.groups as {"sci": {"name": "scientists", "old": "record"}}
+		with input.incoming as [_kafka_msg("group-topic", {"id": "sci", "name": "scientists"})]
+	new == {"groups": {"sci": {"name": "scientists"}}}
+}


### PR DESCRIPTION
This is useful when someone doesn't want to take the topic as-is; or perhaps if multiple topics should be combined into one kind.