### PR TITLE
kafka-multiple-topics: tweak example transform

### DIFF
--- a/examples/kafka-multiple-topics/transform.rego
+++ b/examples/kafka-multiple-topics/transform.rego
@@ -4,9 +4,6 @@ import rego.v1
 
 _payload(msg) := json.unmarshal(base64.decode(msg.value))
 
-# _id() of a message must be unique across its kind
-_id(msg) := json.unmarshal(base64.decode(msg.key))
-
 # _kind() of a message determines where on the resulting data tree its
 # values are to be written. This is useful when you don't want to use the
 # incoming topics as-is.
@@ -14,31 +11,20 @@ _kind(msg) := "groups" if msg.topic == "group-topic"
 
 else := msg.topic
 
-# _key() of a message with kind T is where we'll store its _values()
-# so on kind "users", message with `_id(msg)` of "ada" and `_values(msg)`
-# of {"name": "Ada Lovelace"} will end up as
-#
-# users:
-#   ada:
-#     name: Ada Lovelace
-#
-# in the result of the transform
-_key(msg) := _payload(msg).id
-
 _values("users", payload) := object.filter(payload, ["name", "roles"]) # for users, pluck "name" and "roles"
 
 _values("groups", payload) := object.remove(payload, ["id", "type"]) # for groups, take everything BUT "type"
 
 _values(kind, payload) := payload if not kind in {"users", "groups"} # for other kinds, keep message payload as-is
 
-# this collects all IDs of the messages in a batch, per kind
-batches[_kind(msg)][idx] := _key(msg) if some idx, msg in input.incoming
+# this collects all kinds of the messages in a batch, to determine which aren't updated by the batch
+batches contains _kind(msg) if some msg in input.incoming
 
 # incoming messages are parsed and stored under their ID payload field
-transform[kind][_key(msg)] := _values(kind, payload) if {
-	some kind, msgs in incoming_latest
-	some _, msg in msgs
-	payload := _payload(msg)
+transform[kind][key] := _values(kind, payload) if {
+	some kind, payloads in incoming_latest
+	some _, payload in payloads
+	key := payload.id
 	not is_delete(payload)
 }
 
@@ -55,19 +41,23 @@ transform[kind][key] := val if {
 	no_news_for_key(kind, key)
 }
 
-no_news_for_key(kind, _) if not batches[kind]
+no_news_for_key(kind, _) if not kind in batches
 
-no_news_for_key(kind, key) if not key in object.keys(incoming_latest[kind])
+no_news_for_key(kind, key) if not incoming_latest[kind][key]
 
 # input.incoming is an array, iteration order naturally given
-incoming[_kind(msg)][_key(msg)][batch] := msg if some batch, msg in input.incoming
+incoming[_kind(msg)][key][idx] := payload if {
+	some idx, msg in input.incoming
+	payload := _payload(msg)
+	key := payload.id
+}
 
-incoming_latest[kind][key] := msg if {
+incoming_latest[kind][key] := payload if {
 	some kind, xs in incoming
 	some key, batch in xs
 
 	# batch is an object! iteration order is unspecified -- but it happens to be sorted
 	arr := [i | some i, _ in batch]
 	last := arr[count(arr) - 1]
-	msg := batch[last]
+	payload := batch[last]
 }


### PR DESCRIPTION
* batches: does not need idx, so let's make it a simple multi-value rule
* object.keys() will build intermediate sets that are instantly discarded, do a simple lookup instead.