### PR TITLE
add POST / endpoint for default decisions

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -13,6 +13,37 @@ servers:
 - url: http://localhost:8181
   description: Local development server
 paths:
+  /:
+    post:
+      parameters:
+      - $ref: "#/components/parameters/GzipContentEncoding"
+      - $ref: "#/components/parameters/GzipAcceptEncoding"
+      - $ref: "#/components/parameters/pretty"
+      - $ref: "#/components/parameters/provenance"
+      - $ref: "#/components/parameters/explain"
+      - $ref: "#/components/parameters/metrics"
+      - $ref: "#/components/parameters/instrument"
+      - $ref: "#/components/parameters/strict-builtin-errors"
+      summary: Execute the default decision with given an input
+      operationId: executeDefaultPolicyWithInput
+      x-speakeasy-usage-example: true
+      requestBody:
+        description: The input document
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/input"
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/result"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "500":
+          $ref: "#/components/responses/ServerError"
   /v1/data/{path}:
     get:
       parameters:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -16,14 +16,7 @@ paths:
   /:
     post:
       parameters:
-      - $ref: "#/components/parameters/GzipContentEncoding"
-      - $ref: "#/components/parameters/GzipAcceptEncoding"
       - $ref: "#/components/parameters/pretty"
-      - $ref: "#/components/parameters/provenance"
-      - $ref: "#/components/parameters/explain"
-      - $ref: "#/components/parameters/metrics"
-      - $ref: "#/components/parameters/instrument"
-      - $ref: "#/components/parameters/strict-builtin-errors"
       summary: Execute the default decision with given an input
       operationId: executeDefaultPolicyWithInput
       x-speakeasy-usage-example: true

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -17,7 +17,8 @@ paths:
     post:
       parameters:
       - $ref: "#/components/parameters/pretty"
-      summary: Execute the default decision with given an input
+      - $ref: "#/components/parameters/GzipAcceptEncoding"
+      summary: Execute the default decision  given an input
       operationId: executeDefaultPolicyWithInput
       x-speakeasy-usage-example: true
       requestBody:
@@ -29,12 +30,11 @@ paths:
               $ref: "#/components/schemas/input"
       responses:
         "200":
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/result"
+          $ref: "#/components/responses/SuccessfulDefaultPolicyEvaluation"
         "400":
           $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/PolicyNotFound"
         "500":
           $ref: "#/components/responses/ServerError"
   /v1/data/{path}:
@@ -282,6 +282,24 @@ components:
       properties:
         code: {type: string}
   responses:
+    SuccessfulDefaultPolicyEvaluation:
+      description: >
+        Success.
+
+        Evaluating the default policy has the same response behavior as a successful policy evaluation, but with only the result as the response.
+      headers:
+        "Content-Encoding":
+          $ref: "#/components/headers/GzipContentEncoding"
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/result"
+    PolicyNotFound:
+      description: The policy at the specified location is undefined.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ClientError"
     SuccessfulPolicyEvaluation:
       description: >
         Success.


### PR DESCRIPTION
As described [here](https://www.openpolicyagent.org/docs/latest/rest-api/), the OPA API allows for "default decisions" to be made against a configurable "default rule". To support enabling this feature from the SDKs, I have added an appropriate endpoint to OpenAPI spec. Note that unlike the /v1/data/{path} endpoints, / does not require wrapping the input with `{"input": ... }`, nor does it wrap the result in `{"result": ...}`.