### PR TITLE
README: Manually patch the Regal version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![OPA v0.68.0](https://img.shields.io/endpoint?url=https://openpolicyagent.org/badge-endpoint/v0.68.0) [![Regal v0.25.1-0.20240830084422-6a6f707145fd](https://img.shields.io/github/v/release/styrainc/regal?filter=v0.25.1-0.20240830084422-6a6f707145fd-0.20240830084422-6a6f707145fd&label=Regal)](https://github.com/StyraInc/regal/releases/tag/v0.25.1-0.20240830084422-6a6f707145fd-0.20240830084422-6a6f707145fd)
+![OPA v0.68.0](https://img.shields.io/endpoint?url=https://openpolicyagent.org/badge-endpoint/v0.68.0) [![Regal v0.25.0](https://img.shields.io/github/v/release/styrainc/regal?filter=v0.25.0&label=Regal)](https://github.com/StyraInc/regal/releases/tag/v0.25.0)
 
 
 # Styra Enterprise OPA


### PR DESCRIPTION
## What changed?

This PR manually corrects the Regal version badge-- it got messed up during the last release, due to a piece of release automation nabbing a branch commit hash, instead of the major version.