### PR TITLE
openapi: Extend the `/v1/compile` API

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -10,14 +10,14 @@ externalDocs:
   url: "https://docs.styra.com/enterprise-opa"
   x-openpolicyagent-documentation-url: "https://www.openpolicyagent.org/docs/latest/"
 servers:
-- url: http://localhost:8181
-  description: Local development server
+  - url: http://localhost:8181
+    description: Local development server
 paths:
   /:
     post:
       parameters:
-      - $ref: "#/components/parameters/pretty"
-      - $ref: "#/components/parameters/GzipAcceptEncoding"
+        - $ref: "#/components/parameters/pretty"
+        - $ref: "#/components/parameters/GzipAcceptEncoding"
       summary: Execute the default decision  given an input
       operationId: executeDefaultPolicyWithInput
       x-speakeasy-usage-example: true
@@ -40,14 +40,14 @@ paths:
   /v1/data/{path}:
     get:
       parameters:
-      - $ref: "#/components/parameters/policyPath"
-      - $ref: "#/components/parameters/GzipAcceptEncoding"
-      - $ref: "#/components/parameters/pretty"
-      - $ref: "#/components/parameters/provenance"
-      - $ref: "#/components/parameters/explain"
-      - $ref: "#/components/parameters/metrics"
-      - $ref: "#/components/parameters/instrument"
-      - $ref: "#/components/parameters/strict-builtin-errors"
+        - $ref: "#/components/parameters/policyPath"
+        - $ref: "#/components/parameters/GzipAcceptEncoding"
+        - $ref: "#/components/parameters/pretty"
+        - $ref: "#/components/parameters/provenance"
+        - $ref: "#/components/parameters/explain"
+        - $ref: "#/components/parameters/metrics"
+        - $ref: "#/components/parameters/instrument"
+        - $ref: "#/components/parameters/strict-builtin-errors"
       summary: Execute a policy
       operationId: executePolicy
       responses:
@@ -59,15 +59,15 @@ paths:
           $ref: "#/components/responses/ServerError"
     post:
       parameters:
-      - $ref: "#/components/parameters/policyPath"
-      - $ref: "#/components/parameters/GzipContentEncoding"
-      - $ref: "#/components/parameters/GzipAcceptEncoding"
-      - $ref: "#/components/parameters/pretty"
-      - $ref: "#/components/parameters/provenance"
-      - $ref: "#/components/parameters/explain"
-      - $ref: "#/components/parameters/metrics"
-      - $ref: "#/components/parameters/instrument"
-      - $ref: "#/components/parameters/strict-builtin-errors"
+        - $ref: "#/components/parameters/policyPath"
+        - $ref: "#/components/parameters/GzipContentEncoding"
+        - $ref: "#/components/parameters/GzipAcceptEncoding"
+        - $ref: "#/components/parameters/pretty"
+        - $ref: "#/components/parameters/provenance"
+        - $ref: "#/components/parameters/explain"
+        - $ref: "#/components/parameters/metrics"
+        - $ref: "#/components/parameters/instrument"
+        - $ref: "#/components/parameters/strict-builtin-errors"
       summary: Execute a policy given an input
       operationId: executePolicyWithInput
       x-speakeasy-usage-example: true
@@ -92,15 +92,15 @@ paths:
   /v1/batch/data/{path}:
     post:
       parameters:
-      - $ref: "#/components/parameters/policyPath"
-      - $ref: "#/components/parameters/GzipContentEncoding"
-      - $ref: "#/components/parameters/GzipAcceptEncoding"
-      - $ref: "#/components/parameters/pretty"
-      - $ref: "#/components/parameters/provenance"
-      - $ref: "#/components/parameters/explain"
-      - $ref: "#/components/parameters/metrics"
-      - $ref: "#/components/parameters/instrument"
-      - $ref: "#/components/parameters/strict-builtin-errors"
+        - $ref: "#/components/parameters/policyPath"
+        - $ref: "#/components/parameters/GzipContentEncoding"
+        - $ref: "#/components/parameters/GzipAcceptEncoding"
+        - $ref: "#/components/parameters/pretty"
+        - $ref: "#/components/parameters/provenance"
+        - $ref: "#/components/parameters/explain"
+        - $ref: "#/components/parameters/metrics"
+        - $ref: "#/components/parameters/instrument"
+        - $ref: "#/components/parameters/strict-builtin-errors"
       summary: Execute a policy given a batch of inputs
       operationId: executeBatchPolicyWithInput
       x-speakeasy-usage-example: true
@@ -118,16 +118,17 @@ paths:
                   additionalProperties:
                     $ref: "#/components/schemas/input"
       responses:
-        "200": { $ref: "#/components/responses/BatchSuccessfulPolicyEvaluation" }
+        "200":
+          { $ref: "#/components/responses/BatchSuccessfulPolicyEvaluation" }
         "207": { $ref: "#/components/responses/BatchMixedResults" }
         "400": { $ref: "#/components/responses/BadRequest" }
         "500": { $ref: "#/components/responses/BatchServerError" }
   /health:
     get:
       parameters:
-      - $ref: "#/components/parameters/bundles"
-      - $ref: "#/components/parameters/plugins"
-      - $ref: "#/components/parameters/exclude-plugin"
+        - $ref: "#/components/parameters/bundles"
+        - $ref: "#/components/parameters/plugins"
+        - $ref: "#/components/parameters/exclude-plugin"
       summary: Verify the server is operational
       operationId: health
       description: The health API endpoint executes a simple built-in policy query to verify that the server is operational. Optionally it can account for bundle activation as well (useful for “ready” checks at startup).
@@ -239,32 +240,32 @@ components:
     input:
       description: Arbitrary JSON used within your policies by accessing `input`
       oneOf:
-      - type: boolean
-      - type: string
-      - type: number
-      - type: array
-        items: {}
-      - type: object
-        additionalProperties: true
-        example:
-          user: alice
-          action: read
-          object: id123
-          type: dog
+        - type: boolean
+        - type: string
+        - type: number
+        - type: array
+          items: {}
+        - type: object
+          additionalProperties: true
+          example:
+            user: alice
+            action: read
+            object: id123
+            type: dog
     result:
       description: The base or virtual document referred to by the URL path. If the path is undefined, this key will be omitted.
       oneOf:
-      - type: boolean
-      - type: string
-      - type: number
-      - type: array
-        items: {}
-      - type: object
-        additionalProperties: true
-        example:
-          allow: true
-          user_is_admin: true
-          user_is_granted: []
+        - type: boolean
+        - type: string
+        - type: number
+        - type: array
+          items: {}
+        - type: object
+          additionalProperties: true
+          example:
+            allow: true
+            user_is_admin: true
+            user_is_granted: []
     provenance:
       type: object
       description: Provenance information can be requested on individual API calls and are returned inline with the API response. To obtain provenance information on an API call, specify the `provenance=true` query parameter when executing the API call.
@@ -291,44 +292,44 @@ components:
       type: object
       required: [code, message]
       properties:
-        code: {type: string}
-        message: {type: string}
+        code: { type: string }
+        message: { type: string }
         errors:
           type: array
           items:
             type: object
             required: [code, message]
             properties:
-              code: {type: string}
-              message: {type: string}
+              code: { type: string }
+              message: { type: string }
               location:
                 type: object
                 required: [file, row, col]
                 properties:
-                  file: {type: string}
-                  row: {type: integer}
-                  col: {type: integer}
+                  file: { type: string }
+                  row: { type: integer }
+                  col: { type: integer }
     ServerError:
       type: object
       required: [code, message]
       properties:
-        code: {type: string}
-        message: {type: string}
+        code: { type: string }
+        message: { type: string }
         errors:
           type: array
           items:
             type: object
             required: [code, message]
             properties:
-              code: {type: string}
-              message: {type: string}
+              code: { type: string }
+              message: { type: string }
               location:
                 type: object
                 required: [file, row, col]
                 properties:
-                  file: {type: string}
-                  row: {type: integer}
-                  col: {type: integer}
+                  file: { type: string }
+                  row: { type: integer }
+                  col: { type: integer }
         decision_id:
           type: string
           example: "b84cf736-213c-4932-a8e4-bb5c648f1b4d"
@@ -336,7 +337,7 @@ components:
       type: object
       required: [error]
       properties:
-        code: {type: string}
+        code: { type: string }
     HasStatusCode:
       type: object
       properties:
@@ -345,12 +346,12 @@ components:
       required: [http_status_oode]
     SuccessfulPolicyResponseWithStatusCode:
       allOf:
-        - $ref: '#/components/schemas/HasStatusCode'
-        - $ref: '#/components/schemas/SuccessfulPolicyResponse'
+        - $ref: "#/components/schemas/HasStatusCode"
+        - $ref: "#/components/schemas/SuccessfulPolicyResponse"
     ServerErrorWithStatusCode:
       allOf:
-        - $ref: '#/components/schemas/HasStatusCode'
-        - $ref: '#/components/schemas/ServerError'
+        - $ref: "#/components/schemas/HasStatusCode"
+        - $ref: "#/components/schemas/ServerError"
     SuccessfulPolicyResponse:
       type: object
       properties:
@@ -445,8 +446,8 @@ components:
                       type: string
                       example: "200"
                   oneOf:
-                  - $ref: "#/components/schemas/SuccessfulPolicyResponseWithStatusCode"
-                  - $ref: "#/components/schemas/ServerErrorWithStatusCode"
+                    - $ref: "#/components/schemas/SuccessfulPolicyResponseWithStatusCode"
+                    - $ref: "#/components/schemas/ServerErrorWithStatusCode"
                   discriminator:
                     propertyName: http_status_code
                     mapping:
@@ -492,6 +493,5 @@ components:
             $ref: "#/components/schemas/UnhealthyServer"
 
 security:
-- {}
-- bearerAuth: []
-
+  - {}
+  - bearerAuth: []

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -123,6 +123,43 @@ paths:
         "207": { $ref: "#/components/responses/BatchMixedResults" }
         "400": { $ref: "#/components/responses/BadRequest" }
         "500": { $ref: "#/components/responses/BatchServerError" }
+  /v1/compile:
+    post:
+      parameters:
+        - $ref: "#/components/parameters/GzipAcceptEncoding"
+        - $ref: "#/components/parameters/GzipContentEncoding"
+        - $ref: "#/components/parameters/pretty"
+        - $ref: "#/components/parameters/explain"
+        - $ref: "#/components/parameters/metrics"
+        - $ref: "#/components/parameters/instrument"
+      summary: Partially evaluate a query
+      operationId: compileQueryWithPartialEvaluation
+      x-speakeasy-usage-example: false
+      requestBody:
+        description: The query, input, and other settings for partial evaluation.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [query]
+              properties:
+                query:
+                  $ref: "#/components/schemas/CompileQuery"
+                options:
+                  $ref: "#/components/schemas/CompileOptions"
+                unknowns:
+                  $ref: "#/components/schemas/CompileUnknowns"
+                input:
+                  $ref: "#/components/schemas/input"
+                  description: The input document to use during partial evaluation.
+      responses:
+        "200":
+          $ref: "#/components/responses/CompileResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "500":
+          $ref: "#/components/responses/ServerError"
   /health:
     get:
       parameters:
@@ -366,6 +403,34 @@ components:
           description: If decision logging is enabled, this field contains a string that uniquely identifies the decision. The identifier will be included in the decision log event for this decision. Callers can use the identifier for correlation purposes.
         provenance:
           $ref: "#/components/schemas/provenance"
+    CompileQuery:
+      type: string
+      description: The query to partially evaluate and compile.
+    CompileOptions:
+      type: object
+      description: Additional options to use during partial evaluation. Only disableInlining option is supported.
+      additionalProperties: true
+      properties:
+        disableInlining:
+          type: array
+        targetFormat:
+          type: string
+          enum: [json_ast, sql, ucast]
+    CompileUnknowns:
+      type: array
+      description: The terms to treat as unknown during partial evaluation.
+      default: ["input"]
+    CompileResult:
+      type: object
+      description: The partially evaluated result of the query. Result will be empty if the query is never true.
+      properties:
+        result:
+          type: object
+          description: The partially evaluated result of the query.
+          additionalProperties: true
+          properties:
+            queries:
+              type: array
   responses:
     SuccessfulDefaultPolicyEvaluation:
       description: >
@@ -453,6 +518,16 @@ components:
                     mapping:
                       "200": "#/components/schemas/SuccessfulPolicyResponseWithStatusCode"
                       "500": "#/components/schemas/ServerErrorWithStatusCode"
+    CompileResponse:
+      description: The JSON AST representation of the partially evaluated query.
+      type: object
+      properties:
+        result:
+          $ref: "#/components/schemas/CompileResult"
+        metrics:
+          type: object
+          description: If query metrics are enabled, this field contains query performance metrics collected during the parse, compile, and evaluation steps.
+          additionalProperties: true
     BadRequest:
       description: Bad Request
       content:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -155,7 +155,35 @@ paths:
                   description: The input document to use during partial evaluation.
       responses:
         "200":
-          $ref: "#/components/responses/CompileResponse"
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CompileResultJSON"
+            application/vnd.styra.multitarget+json:
+              schema:
+                $ref: "#/components/schemas/CompileResultMultitarget"
+            application/vnd.styra.ucast.all+json:
+              schema:
+                $ref: "#/components/schemas/CompileResultUCAST"
+            application/vnd.styra.ucast.minimal+json:
+              schema:
+                $ref: "#/components/schemas/CompileResultUCAST"
+            application/vnd.styra.ucast.linq+json:
+              schema:
+                $ref: "#/components/schemas/CompileResultUCAST"
+            application/vnd.styra.ucastprismajson:
+              schema:
+                $ref: "#/components/schemas/CompileResultUCAST"
+            application/vnd.styra.sql.sqlserver+json:
+              schema:
+                $ref: "#/components/schemas/CompileResultSQL"
+            application/vnd.styra.sql.mysql+json:
+              schema:
+                $ref: "#/components/schemas/CompileResultSQL"
+            application/vnd.styra.sql.postgres+json:
+              schema:
+                $ref: "#/components/schemas/CompileResultSQL"
         "400":
           $ref: "#/components/responses/BadRequest"
         "500":
@@ -185,6 +213,14 @@ components:
       schema:
         type: string
         enum: [gzip]
+    CompileMIMEType:
+      description: MIME type for selecting /v1/compile API response format
+      schema:
+        type: string
+        enum:
+          - application/json
+          - application/vnd.styra.ucast+json
+          - application/vnd.styra.sql+json
   parameters:
     policyPath:
       name: path
@@ -372,15 +408,17 @@ components:
           example: "b84cf736-213c-4932-a8e4-bb5c648f1b4d"
     UnhealthyServer:
       type: object
-      required: [error]
+      required: [code]
       properties:
         code: { type: string }
+        errors: { type: array }
+        message: { type: string }
     HasStatusCode:
       type: object
       properties:
         http_status_code:
           type: string
-      required: [http_status_oode]
+      required: [http_status_code]
     SuccessfulPolicyResponseWithStatusCode:
       allOf:
         - $ref: "#/components/schemas/HasStatusCode"
@@ -408,19 +446,40 @@ components:
       description: The query to partially evaluate and compile.
     CompileOptions:
       type: object
-      description: Additional options to use during partial evaluation. Only disableInlining option is supported.
+      description: Additional options to use during partial evaluation. Only the disableInlining option is currently supported in OPA. Enterprise OPA may support additional options.
       additionalProperties: true
       properties:
         disableInlining:
           type: array
-        targetFormat:
-          type: string
-          enum: [json_ast, sql, ucast]
+        targetDialects:
+          type: array
+          description: The output targets for partial evaluation. Different targets will have different constraints.
+          items:
+            type: string
+            enum:
+              - ucast+all
+              - ucast+minimal
+              - ucast+prisma
+              - ucast+linq
+              - sql+sqlserver
+              - sql+mysql
+              - sql+postgres
+        targetSQLTableMappings:
+          type: object
+          properties:
+            sqlserver:
+              type: object
+            mysql:
+              type: object
+            postgres:
+              type: object
     CompileUnknowns:
       type: array
       description: The terms to treat as unknown during partial evaluation.
+      items:
+        type: string
       default: ["input"]
-    CompileResult:
+    CompileResultJSON:
       type: object
       description: The partially evaluated result of the query. Result will be empty if the query is never true.
       properties:
@@ -429,8 +488,70 @@ components:
           description: The partially evaluated result of the query.
           additionalProperties: true
           properties:
-            queries:
-              type: array
+            query:
+              type: object
+            support:
+              type: object
+    CompileResultUCAST:
+      type: object
+      description: The partially evaluated result of the query, in UCAST format. Result will be empty if the query is never true.
+      properties:
+        result:
+          type: object
+          description: The partially evaluated result of the query as UCAST.
+          additionalProperties: true
+          properties:
+            query:
+              type: object
+              description: UCAST JSON object describing the conditions under which the query is true.
+    CompileResultSQL:
+      type: object
+      description: The partially evaluated result of the query, in SQL format. Result will be empty if the query is never true.
+      properties:
+        result:
+          type: object
+          description: The partially evaluated result of the query as SQL.
+          additionalProperties: true
+          properties:
+            query:
+              type: string
+              description: String representing the SQL equivalent of the conditions under which the query is true.
+    CompileResultMultitarget:
+      type: object
+      description: The partially evaluated result of the query, for each target dialect. Result will be empty if the query is never true.
+      properties:
+        result:
+          type: object
+          description: The partially evaluated result of the query in each target dialect.
+          additionalProperties: true
+          properties:
+            targets:
+              type: object
+              properties:
+                ucast:
+                  type: object
+                  properties:
+                    query:
+                      type: object
+                      description: UCAST JSON object describing the conditions under which the query is true.
+                sqlSQLServer:
+                  type: object
+                  properties:
+                    query:
+                      type: string
+                      description: String representing the SQL equivalent of the conditions under which the query is true.
+                sqlMySQL:
+                  type: object
+                  properties:
+                    query:
+                      type: string
+                      description: String representing the SQL equivalent of the conditions under which the query is true.
+                sqlPostgres:
+                  type: object
+                  properties:
+                    query:
+                      type: string
+                      description: String representing the SQL equivalent of the conditions under which the query is true
   responses:
     SuccessfulDefaultPolicyEvaluation:
       description: >
@@ -518,16 +639,6 @@ components:
                     mapping:
                       "200": "#/components/schemas/SuccessfulPolicyResponseWithStatusCode"
                       "500": "#/components/schemas/ServerErrorWithStatusCode"
-    CompileResponse:
-      description: The JSON AST representation of the partially evaluated query.
-      type: object
-      properties:
-        result:
-          $ref: "#/components/schemas/CompileResult"
-        metrics:
-          type: object
-          description: If query metrics are enabled, this field contains query performance metrics collected during the parse, compile, and evaluation steps.
-          additionalProperties: true
     BadRequest:
       description: Bad Request
       content:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -534,19 +534,19 @@ components:
                     query:
                       type: object
                       description: UCAST JSON object describing the conditions under which the query is true.
-                sqlSQLServer:
+                sqlserver:
                   type: object
                   properties:
                     query:
                       type: string
                       description: String representing the SQL equivalent of the conditions under which the query is true.
-                sqlMySQL:
+                mysql:
                   type: object
                   properties:
                     query:
                       type: string
                       description: String representing the SQL equivalent of the conditions under which the query is true.
-                sqlPostgres:
+                postgres:
                   type: object
                   properties:
                     query:


### PR DESCRIPTION
## What changed?

This PR tracks a planned extension to the Enterprise OPA `/v1/compile` API, as part of our intended support for UCAST and data filtering experiments.

Currently, my approach is to add a single additional string option under `"options"` :arrow_right: `"targetFormat"`. Allowed values for the field include: `json_ast` (the default), `sql`, and `ucast`.

Here's what an example `/v1/compile` input might look like:

```
POST /v1/compile HTTP/1.1
Content-Type: application/json
```
```
{
  "query": "data.example.allow == true",
  "input": {
    "subject": {
      "clearance_level": 4
    }
  },
  "options": {
    "disableInlining": [],
    "targetFormat": "sql"
  },
  "unknowns": [
    "data.reports"
  ]
}
```

The response would then resemble:

```
{
  "result": {
    "queries": [
      [
        {
          "index": 0,
          "sql": "WHERE ...\n-- not actually sure what this SQL query would look like for the reference query."
        }
      ]
    ]
  }
}

```