### PR TITLE
openapi: Add `masks` field to /v1/compile results.

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -504,6 +504,9 @@ components:
             query:
               type: object
               description: UCAST JSON object describing the conditions under which the query is true.
+            masks:
+              type: object
+              description: Column masking functions, where the key is the column name, and the value is describes which masking function to use.
     CompileResultSQL:
       type: object
       description: The partially evaluated result of the query, in SQL format. Result will be empty if the query is never true.
@@ -516,6 +519,9 @@ components:
             query:
               type: string
               description: String representing the SQL equivalent of the conditions under which the query is true.
+            masks:
+              type: object
+              description: Column masking functions, where the key is the column name, and the value is describes which masking function to use.
     CompileResultMultitarget:
       type: object
       description: The partially evaluated result of the query, for each target dialect. Result will be empty if the query is never true.
@@ -534,24 +540,36 @@ components:
                     query:
                       type: object
                       description: UCAST JSON object describing the conditions under which the query is true.
+                    masks:
+                      type: object
+                      description: Column masking functions, where the key is the column name, and the value is describes which masking function to use.
                 sqlserver:
                   type: object
                   properties:
                     query:
                       type: string
                       description: String representing the SQL equivalent of the conditions under which the query is true.
+                    masks:
+                      type: object
+                      description: Column masking functions, where the key is the column name, and the value is describes which masking function to use.
                 mysql:
                   type: object
                   properties:
                     query:
                       type: string
                       description: String representing the SQL equivalent of the conditions under which the query is true.
+                    masks:
+                      type: object
+                      description: Column masking functions, where the key is the column name, and the value is describes which masking function to use.
                 postgres:
                   type: object
                   properties:
                     query:
                       type: string
                       description: String representing the SQL equivalent of the conditions under which the query is true
+                    masks:
+                      type: object
+                      description: Column masking functions, where the key is the column name, and the value is describes which masking function to use.
   responses:
     SuccessfulDefaultPolicyEvaluation:
       description: >

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -594,12 +594,6 @@ components:
                 - type: array
                 - type: object
                   additionalProperties: true
-        - properties:
-            hash-sha256:
-              type: object
-        - properties:
-            lastN:
-              type: integer
   responses:
     SuccessfulDefaultPolicyEvaluation:
       description: >

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -411,7 +411,7 @@ components:
       required: [code]
       properties:
         code: { type: string }
-        errors: { type: array }
+        error: { type: string }
         message: { type: string }
     HasStatusCode:
       type: object

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -443,6 +443,9 @@ components:
       properties:
         disableInlining:
           type: array
+          description: A list of paths to exclude from partial evaluation inlining.
+          items:
+            type: string
         targetDialects:
           type: array
           description: The output targets for partial evaluation. Different targets will have different constraints.
@@ -584,6 +587,7 @@ components:
                 - type: string
                 - type: number
                 - type: array
+                  items: {}
                 - type: object
                   additionalProperties: true
   responses:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -501,7 +501,7 @@ components:
               description: UCAST JSON object describing the conditions under which the query is true.
             masks:
               type: object
-              description: Column masking functions, where the key is the column name, and the value describes which masking function to use.
+              description: Column masking rules, where the key is the column name, and the value describes which masking function to use.
               additionalProperties:
                 $ref: "#/components/schemas/MaskingRule"
     CompileResultSQL:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -181,7 +181,7 @@ paths:
             application/vnd.styra.sql.mysql+json:
               schema:
                 $ref: "#/components/schemas/CompileResultSQL"
-            application/vnd.styra.sql.postgres+json:
+            application/vnd.styra.sql.postgresql+json:
               schema:
                 $ref: "#/components/schemas/CompileResultSQL"
         "400":
@@ -463,7 +463,7 @@ components:
               - ucast+linq
               - sql+sqlserver
               - sql+mysql
-              - sql+postgres
+              - sql+postgresql
         targetSQLTableMappings:
           type: object
           properties:
@@ -471,7 +471,7 @@ components:
               type: object
             mysql:
               type: object
-            postgres:
+            postgresql:
               type: object
     CompileUnknowns:
       type: array
@@ -571,7 +571,7 @@ components:
                       description: Column masking functions, where the key is the column name, and the value describes which masking function to use.
                       additionalProperties:
                         $ref: "#/components/schemas/MaskingRule"
-                postgres:
+                postgresql:
                   type: object
                   properties:
                     query:
@@ -587,11 +587,16 @@ components:
       oneOf:
         - properties:
             replace:
-              type: string
+              oneOf:
+                - type: boolean
+                - type: string
+                - type: number
+                - type: array
+                - type: object
+                  additionalProperties: true
         - properties:
             hash-sha256:
               type: object
-              additionalProperties: false
         - properties:
             lastN:
               type: integer

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -213,14 +213,6 @@ components:
       schema:
         type: string
         enum: [gzip]
-    CompileMIMEType:
-      description: MIME type for selecting /v1/compile API response format
-      schema:
-        type: string
-        enum:
-          - application/json
-          - application/vnd.styra.ucast+json
-          - application/vnd.styra.sql+json
   parameters:
     policyPath:
       name: path

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -506,7 +506,9 @@ components:
               description: UCAST JSON object describing the conditions under which the query is true.
             masks:
               type: object
-              description: Column masking functions, where the key is the column name, and the value is describes which masking function to use.
+              description: Column masking functions, where the key is the column name, and the value describes which masking function to use.
+              additionalProperties:
+                $ref: "#/components/schemas/MaskingRule"
     CompileResultSQL:
       type: object
       description: The partially evaluated result of the query, in SQL format. Result will be empty if the query is never true.
@@ -521,7 +523,9 @@ components:
               description: String representing the SQL equivalent of the conditions under which the query is true.
             masks:
               type: object
-              description: Column masking functions, where the key is the column name, and the value is describes which masking function to use.
+              description: Column masking functions, where the key is the column name, and the value describes which masking function to use.
+              additionalProperties:
+                $ref: "#/components/schemas/MaskingRule"
     CompileResultMultitarget:
       type: object
       description: The partially evaluated result of the query, for each target dialect. Result will be empty if the query is never true.
@@ -542,7 +546,9 @@ components:
                       description: UCAST JSON object describing the conditions under which the query is true.
                     masks:
                       type: object
-                      description: Column masking functions, where the key is the column name, and the value is describes which masking function to use.
+                      description: Column masking functions, where the key is the column name, and the value describes which masking function to use.
+                      additionalProperties:
+                        $ref: "#/components/schemas/MaskingRule"
                 sqlserver:
                   type: object
                   properties:
@@ -551,7 +557,9 @@ components:
                       description: String representing the SQL equivalent of the conditions under which the query is true.
                     masks:
                       type: object
-                      description: Column masking functions, where the key is the column name, and the value is describes which masking function to use.
+                      description: Column masking functions, where the key is the column name, and the value describes which masking function to use.
+                      additionalProperties:
+                        $ref: "#/components/schemas/MaskingRule"
                 mysql:
                   type: object
                   properties:
@@ -560,7 +568,9 @@ components:
                       description: String representing the SQL equivalent of the conditions under which the query is true.
                     masks:
                       type: object
-                      description: Column masking functions, where the key is the column name, and the value is describes which masking function to use.
+                      description: Column masking functions, where the key is the column name, and the value describes which masking function to use.
+                      additionalProperties:
+                        $ref: "#/components/schemas/MaskingRule"
                 postgres:
                   type: object
                   properties:
@@ -569,7 +579,22 @@ components:
                       description: String representing the SQL equivalent of the conditions under which the query is true
                     masks:
                       type: object
-                      description: Column masking functions, where the key is the column name, and the value is describes which masking function to use.
+                      description: Column masking functions, where the key is the column name, and the value describes which masking function to use.
+                      additionalProperties:
+                        $ref: "#/components/schemas/MaskingRule"
+    MaskingRule:
+      type: object
+      oneOf:
+        - properties:
+            replace:
+              type: string
+        - properties:
+            hash-sha256:
+              type: object
+              additionalProperties: false
+        - properties:
+            lastN:
+              type: integer
   responses:
     SuccessfulDefaultPolicyEvaluation:
       description: >


### PR DESCRIPTION
## What Changed?

This PR adds an object property to each `/v1/compile` return type, allowing us to include masking rules in the output for later consumption by downstream tooling.

What I have in mind for masking rules looks roughly like:
```json
{
  "masks": {
    "tickets.assignee": { "replace": ["***"] },
    "tickets.customer.id": { "md5hash": [] },
    "tickets.customer.phone": { "lastN": [4] }
  }
}
```
Where the key is the column name, and the value is an object of the form `{"mask_function": [args...]}`

## Open Questions

 - Do we want to allow providing masks as an HTTP request argument? (Ex: add a new key like `options.masks`)
 - Do we want to allow shorthand syntaxes? (Ex: `"tickets.assignee": "***"` would indicate a replacement with the constant string `***`)
 - This design makes a number of assumptions. Are there any obvious edge cases that this design would be poor for handling?