### PR TITLE
ci: Add Dependabot for JS / GH Actions.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: "npm"
-    directory: "/"
+    directory: "/examples/grpc-typescript"
     schedule:
       interval: "weekly"
   - package-ecosystem: github-actions

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,16 @@ updates:
     schedule:
       interval: "weekly"
   - package-ecosystem: github-actions
-    directory: /
+    directory: "/"
+    schedule:
+      interval: weekly
+  - package-ecosystem: gomod
+    open-pull-requests-limit: 10
+    directory: "/"
+    schedule:
+      interval: weekly
+  - package-ecosystem: gomod
+    open-pull-requests-limit: 10
+    directory: "/examples/go-grpc"
     schedule:
       interval: weekly


### PR DESCRIPTION
## What changed?

This PR adds Dependabot to this repository, allowing it to auto-bump dependencies in our `examples/` folder.

Currently, I've added `npm` and `github-actions` ecosystems-- the Golang setup will require one entry per example folder, since each one has its own `go.{mod,sum}` now.