### PR TITLE
openapi: allow for arbitrary objects in the UCAST compile resp's query

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -499,6 +499,7 @@ components:
             query:
               type: object
               description: UCAST JSON object describing the conditions under which the query is true.
+              additionalProperties: true
             masks:
               type: object
               description: Column masking rules, where the key is the column name, and the value describes which masking function to use.


### PR DESCRIPTION
The effect can be seen [here](https://github.com/StyraInc/opa-typescript/pull/539/files#diff-9e69996adc202c3643a4804f8d87625d09449e54e5cf19c74d8afd580a803299), where I've run the code generation with a local overlay.

[See here for rationale on why SE does what it does](https://www.speakeasy.com/guides/openapi/additionalproperties). I think they have a good point, but for UCAST, we really don't win much by describing the potential types, I think. If the need arises, we can still tighten our definitions.