### PR TITLE
openapi: Add `Options.maskRule` to Compile API.

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -478,6 +478,9 @@ components:
             sqlite:
               type: object
               additionalProperties: true
+        maskRule:
+          type: string
+          description: The Rego rule to evaluate for generating column masks.
     CompileUnknowns:
       type: array
       description: The terms to treat as unknown during partial evaluation.


### PR DESCRIPTION
## What changed?

This PR extends the Open API spec to account for a recently-added (unreleased) `/v1/compile` request option: `maskRule`.

This option explicitly specifies which masking rule to use (Ex: `data.filters.masks`). Because it overrides masking rules set through annotations in the policy, it provides a convenient escape hatch during debugging and development of masking policies.