### PR TITLE
openapi: Add required Accept header for Compile API.

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -127,6 +127,7 @@ paths:
     post:
       parameters:
         - $ref: "#/components/parameters/policyPath"
+        - $ref: "#/components/parameters/CompileAcceptTypes"
         - $ref: "#/components/parameters/GzipAcceptEncoding"
         - $ref: "#/components/parameters/GzipContentEncoding"
         - $ref: "#/components/parameters/pretty"
@@ -240,6 +241,24 @@ components:
       schema:
         type: string
         enum: [gzip]
+    CompileAcceptTypes:
+      name: Accept
+      description: "Indicates the server should generate the target format of data filters."
+      in: header
+      required: true
+      schema:
+        type: string
+        enum:
+          - application/json
+          - application/vnd.styra.multitarget+json
+          - application/vnd.styra.ucast.all+json
+          - application/vnd.styra.ucast.minimal+json
+          - application/vnd.styra.ucast.linq+json
+          - application/vnd.styra.ucast.prisma+json
+          - application/vnd.styra.sql.sqlserver+json
+          - application/vnd.styra.sql.mysql+json
+          - application/vnd.styra.sql.postgresql+json
+          - application/vnd.styra.sql.sqlite+json
     pretty:
       name: pretty
       description: If parameter is `true`, response will formatted for humans.


### PR DESCRIPTION
## What changed?

While we specified in the past what `Accept` headers will give which responses for the Compile API, Speakeasy and other tools need a bit more information to properly understand the space of `Accept` headers the Compile API endpoint will accept.

This PR spells out explicitly which `Accept` headers we use, and marks the header as a required parameter type, which matches the endpoint's expectations (it will error if no `Accept` header is present).