### PR TITLE
openapi: Fix Compile API `Accept` headers, Part II

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -127,7 +127,6 @@ paths:
     post:
       parameters:
         - $ref: "#/components/parameters/policyPath"
-        - $ref: "#/components/parameters/CompileAcceptTypes"
         - $ref: "#/components/parameters/GzipAcceptEncoding"
         - $ref: "#/components/parameters/GzipContentEncoding"
         - $ref: "#/components/parameters/pretty"
@@ -145,6 +144,105 @@ paths:
             schema:
               type: object
               required: [query]
+              properties:
+                options:
+                  $ref: "#/components/schemas/CompileOptions"
+                unknowns:
+                  $ref: "#/components/schemas/CompileUnknowns"
+                input:
+                  $ref: "#/components/schemas/input"
+                  description: The input document to use during partial evaluation.
+          application/vnd.styra.multitarget+json:
+            schema:
+              type: object
+              properties:
+                options:
+                  $ref: "#/components/schemas/CompileOptions"
+                unknowns:
+                  $ref: "#/components/schemas/CompileUnknowns"
+                input:
+                  $ref: "#/components/schemas/input"
+                  description: The input document to use during partial evaluation.
+          application/vnd.styra.ucast.all+json:
+            schema:
+              type: object
+              properties:
+                options:
+                  $ref: "#/components/schemas/CompileOptions"
+                unknowns:
+                  $ref: "#/components/schemas/CompileUnknowns"
+                input:
+                  $ref: "#/components/schemas/input"
+                  description: The input document to use during partial evaluation.
+          application/vnd.styra.ucast.minimal+json:
+            schema:
+              type: object
+              properties:
+                options:
+                  $ref: "#/components/schemas/CompileOptions"
+                unknowns:
+                  $ref: "#/components/schemas/CompileUnknowns"
+                input:
+                  $ref: "#/components/schemas/input"
+                  description: The input document to use during partial evaluation.
+          application/vnd.styra.ucast.linq+json:
+            schema:
+              type: object
+              properties:
+                options:
+                  $ref: "#/components/schemas/CompileOptions"
+                unknowns:
+                  $ref: "#/components/schemas/CompileUnknowns"
+                input:
+                  $ref: "#/components/schemas/input"
+                  description: The input document to use during partial evaluation.
+          application/vnd.styra.ucast.prisma+json:
+            schema:
+              type: object
+              properties:
+                options:
+                  $ref: "#/components/schemas/CompileOptions"
+                unknowns:
+                  $ref: "#/components/schemas/CompileUnknowns"
+                input:
+                  $ref: "#/components/schemas/input"
+                  description: The input document to use during partial evaluation.
+          application/vnd.styra.sql.sqlserver+json:
+            schema:
+              type: object
+              properties:
+                options:
+                  $ref: "#/components/schemas/CompileOptions"
+                unknowns:
+                  $ref: "#/components/schemas/CompileUnknowns"
+                input:
+                  $ref: "#/components/schemas/input"
+                  description: The input document to use during partial evaluation.
+          application/vnd.styra.sql.mysql+json:
+            schema:
+              type: object
+              properties:
+                options:
+                  $ref: "#/components/schemas/CompileOptions"
+                unknowns:
+                  $ref: "#/components/schemas/CompileUnknowns"
+                input:
+                  $ref: "#/components/schemas/input"
+                  description: The input document to use during partial evaluation.
+          application/vnd.styra.sql.postgresql+json:
+            schema:
+              type: object
+              properties:
+                options:
+                  $ref: "#/components/schemas/CompileOptions"
+                unknowns:
+                  $ref: "#/components/schemas/CompileUnknowns"
+                input:
+                  $ref: "#/components/schemas/input"
+                  description: The input document to use during partial evaluation.
+          application/vnd.styra.sql.sqlite+json:
+            schema:
+              type: object
               properties:
                 options:
                   $ref: "#/components/schemas/CompileOptions"
@@ -241,24 +339,6 @@ components:
       schema:
         type: string
         enum: [gzip]
-    CompileAcceptTypes:
-      name: Accept
-      description: "Indicates the server should generate the target format of data filters."
-      in: header
-      required: true
-      schema:
-        type: string
-        enum:
-          - application/json
-          - application/vnd.styra.multitarget+json
-          - application/vnd.styra.ucast.all+json
-          - application/vnd.styra.ucast.minimal+json
-          - application/vnd.styra.ucast.linq+json
-          - application/vnd.styra.ucast.prisma+json
-          - application/vnd.styra.sql.sqlserver+json
-          - application/vnd.styra.sql.mysql+json
-          - application/vnd.styra.sql.postgresql+json
-          - application/vnd.styra.sql.sqlite+json
     pretty:
       name: pretty
       description: If parameter is `true`, response will formatted for humans.


### PR DESCRIPTION
## What Changed?

This commit reworks how we specify the `Accept` header options. Previously, I specified them as a required request parameter, which was syntactically legal, but was ignored by some tools. (e.g. Speakeasy)

This time around, I've mapped out each `Accept` header uniformly under `requestBody > content > $header` to ensure they are picked up consistently by most tools.

## Additional Resources

 - [Speakeasy docs](https://www.speakeasy.com/docs/customize/runtime/override-accept-headers) page on overriding `Accept` headers.